### PR TITLE
[タスク] 時間管理画面の上部タイトルとタイマータブの間に分け目をつける

### DIFF
--- a/lib/Views/StopWatch/StopWatchMainPage.dart
+++ b/lib/Views/StopWatch/StopWatchMainPage.dart
@@ -5,8 +5,8 @@ import 'package:mytodoapp/Views/TodoList/TodoAddPage.dart';
 
 class StopWatchMainPage extends StatelessWidget {
   final _tab = <Tab>[
-    const Tab(text: 'タイマー', icon: Icon(Icons.av_timer)),
-    const Tab(text: 'ストップウォッチ', icon: Icon(Icons.timer)),
+    const Tab(icon: Icon(Icons.av_timer), height: 40),
+    const Tab( icon: Icon(Icons.timer), height: 40),
   ];
   final DisplayData displayData;
 
@@ -20,7 +20,7 @@ class StopWatchMainPage extends StatelessWidget {
           appBar: AppBar(
             title: const Text("時間管理"),
             bottom: TabBar(
-              tabs: _tab,
+              tabs: _tab,              
             ),
           ),
           body: TabBarView(


### PR DESCRIPTION


https://github.com/p238049y/todoappByFlutter/issues/39